### PR TITLE
Rename fold train indices variable

### DIFF
--- a/R/compute_cv_means.R
+++ b/R/compute_cv_means.R
@@ -118,15 +118,15 @@ compute_crossvalidated_means_sl <- function(sl_data,
         rlang::abort("Required method 'train_indices' is not available in scope.")
     }
 
-    train_indices <- train_indices(cv_spec, i)
+    fold_train_idx <- train_indices(cv_spec, i)
 
-    if (length(train_indices) == 0) {
+    if (length(fold_train_idx) == 0) {
       warning(paste("Fold", i, "has no training samples. Skipping."))
       next
     }
 
-    train_data_fold <- sl_data[train_indices, , drop = FALSE]
-    train_labels_fold <- condition_labels[train_indices]
+    train_data_fold <- sl_data[fold_train_idx, , drop = FALSE]
+    train_labels_fold <- condition_labels[fold_train_idx]
 
     fold_means_mat <- NULL
     # Ensure there are rows and labels to process


### PR DESCRIPTION
## Summary
- rename the variable holding fold training indices to `fold_train_idx`
- update subsequent uses to reference new variable

## Testing
- `R -q -e "devtools::test()"` *(fails: `R` command not found)*