### PR TITLE
Fix print.vector_rsa_model distfun label

### DIFF
--- a/R/vector_rsa_model.R
+++ b/R/vector_rsa_model.R
@@ -279,7 +279,14 @@ print.vector_rsa_model <- function(x, ...) {
 
   # Model Specification
   cat("Model Specification:\\n")
-  cat("  |- Distance Function:   ", deparse(substitute(x$distfun)), "\\n")
+  dist_name <- tryCatch({
+    if (!is.null(x$distfun$name)) {
+      x$distfun$name
+    } else {
+      class(x$distfun)[1]
+    }
+  }, error = function(e) class(x$distfun)[1])
+  cat("  |- Distance Function:   ", dist_name, "\\n")
   cat("  |- RSA Similarity Func: ", x$rsa_simfun, "\\n\\n")
 
   # Footer


### PR DESCRIPTION
## Summary
- update `print.vector_rsa_model` to show the distance function name

## Testing
- `R --version` *(fails: command not found)*