### PR TITLE
Fix GLMNet feature dimension check

### DIFF
--- a/R/feature_rsa_model.R
+++ b/R/feature_rsa_model.R
@@ -371,7 +371,7 @@ feature_rsa_model <- function(dataset,
   # Check feature dimensions
   if (ncol(F_new) != length(model$glmnet_f_mean)) {
     stop(sprintf("Feature matrix dimension mismatch for GLMNet: expected %d features but got %d.",
-                ncol(model$glmnet_f_mean), ncol(F_new)))
+                 length(model$glmnet_f_mean), ncol(F_new)))
   }
   
   

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -12139,7 +12139,7 @@ feature_rsa_model <- function(dataset,
   # Check feature dimensions
   if (ncol(F_new) != length(model$glmnet_f_mean)) {
     stop(sprintf("Feature matrix dimension mismatch for GLMNet: expected %d features but got %d.",
-                ncol(model$glmnet_f_mean), ncol(F_new)))
+                length(model$glmnet_f_mean), ncol(F_new)))
   }
   
   


### PR DESCRIPTION
## Summary
- ensure GLMNet feature dimension check uses length of stored means
- keep feature means/sds used as vectors

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*