### PR TITLE
add block_var to feature rsa design

### DIFF
--- a/man/feature_rsa_design.Rd
+++ b/man/feature_rsa_design.Rd
@@ -4,7 +4,8 @@
 \alias{feature_rsa_design}
 \title{Create a Feature-Based RSA Design}
 \usage{
-feature_rsa_design(S = NULL, F = NULL, labels, k = 0, max_comps = 10)
+feature_rsa_design(S = NULL, F = NULL, labels, k = 0, max_comps = 10,
+  block_var = NULL)
 }
 \arguments{
 \item{S}{A symmetric similarity matrix representing the feature space relationships. 
@@ -21,6 +22,10 @@ This parameter is ignored if F is supplied directly (k becomes ncol(F)).}
 \item{max_comps}{Initial upper limit for the number of components to be derived from the
 feature space F by subsequent `feature_rsa_model` methods (PCA, PLS, SCCA).
 This value is automatically capped by the final feature dimensionality `k`. Default 10.}
+
+\item{block_var}{Optional blocking variable used to automatically create a
+blocked cross-validation specification when `crossval` is not supplied to
+\code{feature_rsa_model}.}
 }
 \value{
 A \code{feature_rsa_design} object (S3 class) containing:
@@ -30,6 +35,7 @@ A \code{feature_rsa_design} object (S3 class) containing:
     \item{labels}{Vector of observation labels}
     \item{k}{The final number of feature dimensions used}
     \item{max_comps}{The upper limit on components (<= k)}
+    \item{block_var}{Optional blocking variable for cross-validation}
   }
 }
 \description{

--- a/man/feature_rsa_model.Rd
+++ b/man/feature_rsa_model.Rd
@@ -33,7 +33,9 @@ and including the component limit (`max_comps`).}
   \item{glmnet}{Elastic net regression predicting X from F using glmnet with multivariate Gaussian response.}
 }}
 
-\item{crossval}{Optional cross-validation specification.}
+\item{crossval}{Cross-validation specification. If \code{NULL}, a blocked
+cross-validation scheme will be created automatically when
+\code{design$block_var} is present.}
 
 \item{cache_pca}{Logical, if TRUE and method is "pca", cache the PCA decomposition of the
 feature matrix F across cross-validation folds involving the same training rows.


### PR DESCRIPTION
## Summary
- allow `feature_rsa_design()` to store a block variable
- make `feature_rsa_model()` require a cross-validation spec or use the design's block variable
- document the new argument and behaviour

## Testing
- `R` was unavailable so tests could not be executed