### PR TITLE
Centralize train_model docs

### DIFF
--- a/R/allgeneric.R
+++ b/R/allgeneric.R
@@ -221,6 +221,41 @@ process_roi_default <- function(mod_spec, roi, rnum, center_global_id = NA, ...)
 #'
 #' @return A trained model object. The exact return value depends on the specific
 #'   method implementation.
+#'
+#' @examples
+#' \donttest{
+#'   # Generate a small sample dataset for classification
+#'   dset_info <- gen_sample_dataset(
+#'     D = c(8, 8, 8),
+#'     nobs = 20,
+#'     response_type = "categorical",
+#'     data_mode = "image",
+#'     nlevels = 2
+#'   )
+#'
+#'   # Create a cross-validation specification
+#'   cval <- blocked_cross_validation(dset_info$design$block_var)
+#'
+#'   # Load a simple classifier
+#'   sda_model <- load_model("sda_notune")
+#'
+#'   # Create an MVPA model specification
+#'   mspec <- mvpa_model(
+#'     model = sda_model,
+#'     dataset = dset_info$dataset,
+#'     design = dset_info$design,
+#'     model_type = "classification",
+#'     crossval = cval
+#'   )
+#'
+#'   # Train the model
+#'   fit <- train_model(
+#'     mspec,
+#'     dset_info$dataset$train_data,
+#'     dset_info$design$y_train,
+#'     indices = seq_len(ncol(dset_info$dataset$train_data))
+#'   )
+#' }
 #' @export
 train_model <- function(obj,...) {
   UseMethod("train_model")

--- a/R/contrast_rsa_model.R
+++ b/R/contrast_rsa_model.R
@@ -385,18 +385,13 @@ print.contrast_rsa_model <- function(x, ...) {
 #' @examples
 #' # This example shows the structure of the returned list but doesn't actually run the function
 #' # For a multi-metric model: output_metric = c("beta_delta", "recon_score", "beta_only")
-#' # With 2 contrasts named "contrast1" and "contrast2", the return structure would be:
-#' # 
-#' # result <- list(
-#' #   beta_delta = c(contrast1 = 0.23, contrast2 = -0.15),
-#' #   recon_score = 0.72,
-#' #   beta_only = c(contrast1 = 1.45, contrast2 = 0.88)
-#' # )
-#' #
-#' # Accessing individual metrics:
-#' # result$beta_delta["contrast1"]  # Value for first contrast's beta*delta
-#' # result$recon_score              # Single value for reconstruction score
-#' 
+#' @rdname train_model
+#' @param obj An object of class \code{contrast_rsa_model}.
+#' @param sl_data The data matrix for the current searchlight (samples x voxels).
+#' @param sl_info A list containing information about the current searchlight, including \code{center_local_id}.
+#' @param cv_spec The cross-validation specification.
+#' @param ... Additional arguments (currently ignored).
+#' @return A named list where each element corresponds to a requested metric from \code{obj$output_metric}.
 #' @importFrom stats cor dist lm coef sd terms
 #' @importFrom rlang abort
 #' @method train_model contrast_rsa_model

--- a/R/feature_rsa_model.R
+++ b/R/feature_rsa_model.R
@@ -971,6 +971,14 @@ evaluate_model.feature_rsa_model <- function(object,
 }
 
 
+#' @rdname train_model
+#' @param obj An object of class \code{feature_rsa_model}.
+#' @param X Brain data (samples x voxels).
+#' @param y Feature matrix used for RSA (samples x features).
+#' @param indices Spatial indices associated with the training data.
+#' @param ... Additional arguments.
+#' @return A list containing RSA metrics and, if requested, permutation results.
+#' @method train_model feature_rsa_model
 #' @export
 train_model.feature_rsa_model <- function(obj, X, y, indices, ...) {
   

--- a/R/manova_model.R
+++ b/R/manova_model.R
@@ -77,11 +77,13 @@ manova_model <- function(dataset,
 #'
 #' @param obj An object of class \code{manova_model}.
 #' @param train_dat The training data.
+#' @rdname train_model
 #' @param y the response variable
 #' @param indices The indices of the training data.
 #' @param ... Additional arguments passed to the training method.
 #' @return A named numeric vector of -log(p-values) for each predictor in the MANOVA model.
 #' @importFrom stats as.formula
+#' @method train_model manova_model
 train_model.manova_model <- function(obj, train_dat, y, indices, ...) {
   dframe <- obj$design$data
   dframe$response <- as.matrix(train_dat)

--- a/R/model_fit.R
+++ b/R/model_fit.R
@@ -368,10 +368,7 @@ predict.list_model <- function(object, newdata=NULL,...) {
 
 
 
-#' Train an MVPA Model
-#'
-#' This function trains a Multi-Variate Pattern Analysis (MVPA) model on the provided data, taking care of feature selection, parameter tuning, and model fitting.
-#'
+#' @rdname train_model
 #' @param obj An object of class \code{mvpa_model}, specifying the MVPA problem.
 #' @param train_dat Training data, an instance of class \code{ROIVolume} or \code{ROISurface}.
 #' @param y The dependent variable (response variable), either a numeric vector or a factor.
@@ -379,6 +376,7 @@ predict.list_model <- function(object, newdata=NULL,...) {
 #' @param wts Optional class weights (if the underlying model supports it).
 #' @param ... Additional arguments passed to other methods.
 #' @return A model fit object containing the trained model, its fit, the model type (classification or regression), the best tuning parameters, the voxel indices, and the feature mask.
+#' @method train_model mvpa_model
 train_model.mvpa_model <- function(obj, train_dat, y, indices, wts=NULL, ...) {
   
   tryCatch({

--- a/R/rsa_model.R
+++ b/R/rsa_model.R
@@ -346,16 +346,13 @@ run_lm_semipartial <- function(dvec, obj) {
 ################################################################################
 # TRAINING METHOD
 ################################################################################
-#' Train an RSA Model
-#'
-#' This function trains an RSA (representational similarity analysis) model using the specified method and distance calculation.
-#'
+#' @rdname train_model
 #' @param obj An object of class \code{rsa_model}.
 #' @param train_dat The training data.
 #' @param y The response variable.
 #' @param indices The indices of the training data.
 #' @param ... Additional arguments passed to the training method.
-#' @return 
+#' @return
 #' Depending on \code{obj$regtype}:
 #' \itemize{
 #'   \item \code{"lm"} + no constraints + \code{obj$semipartial=TRUE}: semi-partial correlations
@@ -364,6 +361,7 @@ run_lm_semipartial <- function(dvec, obj) {
 #'   \item \code{"rfit"}: robust regression coefficients
 #'   \item \code{"pearson"} or \code{"spearman"}: correlation coefficients
 #' }
+#' @method train_model rsa_model
 #' @export
 train_model.rsa_model <- function(obj, train_dat, y, indices, ...) {
   # 1) correlation-based distance

--- a/R/vector_rsa_model.R
+++ b/R/vector_rsa_model.R
@@ -109,12 +109,14 @@ vector_rsa_model <- function(dataset, design,
 #' Train a vector RSA model
 #'
 #' @param obj An object of class \code{vector_rsa_model}.
+#' @rdname train_model
 #' @param train_dat A data frame or matrix representing the training subset (e.g., voxel intensities).
 #' @param y Not used in vector RSA (here for consistency with other train_model generics).
 #' @param indices The spatial indices of the training data (ROI, searchlight, etc.).
 #' @param ... Additional arguments.
-#' 
+#'
 #' @return A structure containing "scores" or similar second-order similarity results.
+#' @method train_model vector_rsa_model
 #' @export
 train_model.vector_rsa_model <- function(obj, train_dat, y, indices, ...) {
   # "Training" here is effectively computing RSA-based metrics

--- a/man/train_model.Rd
+++ b/man/train_model.Rd
@@ -20,3 +20,24 @@ This is a generic function that trains a model based on the provided
 model specification object. Different model types will have different
 methods implemented with specific parameters.
 }
+\examples{
+\donttest{
+  dset_info <- gen_sample_dataset(D = c(8, 8, 8), nobs = 20,
+    response_type = "categorical", data_mode = "image", nlevels = 2)
+  cval <- blocked_cross_validation(dset_info$design$block_var)
+  sda_model <- load_model("sda_notune")
+  mspec <- mvpa_model(
+    model = sda_model,
+    dataset = dset_info$dataset,
+    design = dset_info$design,
+    model_type = "classification",
+    crossval = cval
+  )
+  fit <- train_model(
+    mspec,
+    dset_info$dataset$train_data,
+    dset_info$design$y_train,
+    indices = seq_len(ncol(dset_info$dataset$train_data))
+  )
+}
+}

--- a/man/train_model.manova_model.Rd
+++ b/man/train_model.manova_model.Rd
@@ -23,3 +23,15 @@ A named numeric vector of -log(p-values) for each predictor in the MANOVA model.
 \description{
 This function trains a multivariate analysis of variance (MANOVA) model using the specified design.
 }
+\examples{
+\donttest{
+  dset_info <- gen_sample_dataset(D = c(8, 8, 8), nobs = 20,
+    response_type = "categorical", data_mode = "image", nlevels = 2)
+  dismat <- dist(matrix(rnorm(20 * 20), 20, 20))
+  rdes <- rsa_design(~ dismat, list(dismat = dismat))
+  man_mod <- manova_model(rdes)
+  train_model(man_mod, dset_info$dataset$train_data,
+    dset_info$design$y_train,
+    indices = seq_len(ncol(dset_info$dataset$train_data)))
+}
+}

--- a/man/train_model.mvpa_model.Rd
+++ b/man/train_model.mvpa_model.Rd
@@ -25,3 +25,21 @@ A model fit object containing the trained model, its fit, the model type (classi
 \description{
 This function trains a Multi-Variate Pattern Analysis (MVPA) model on the provided data, taking care of feature selection, parameter tuning, and model fitting.
 }
+\examples{
+\donttest{
+  dset_info <- gen_sample_dataset(D = c(8, 8, 8), nobs = 20,
+    response_type = "categorical", data_mode = "image", nlevels = 2)
+  cval <- blocked_cross_validation(dset_info$design$block_var)
+  sda_model <- load_model("sda_notune")
+  mspec <- mvpa_model(
+    model = sda_model,
+    dataset = dset_info$dataset,
+    design = dset_info$design,
+    model_type = "classification",
+    crossval = cval
+  )
+  train_model(mspec, dset_info$dataset$train_data,
+    dset_info$design$y_train,
+    indices = seq_len(ncol(dset_info$dataset$train_data)))
+}
+}

--- a/man/train_model.rsa_model.Rd
+++ b/man/train_model.rsa_model.Rd
@@ -30,3 +30,15 @@ Depending on \code{obj$regtype}:
 \description{
 This function trains an RSA (representational similarity analysis) model using the specified method and distance calculation.
 }
+\examples{
+\donttest{
+  dset_info <- gen_sample_dataset(D = c(8, 8, 8), nobs = 20,
+    response_type = "categorical", data_mode = "image", nlevels = 2)
+  dismat <- dist(matrix(rnorm(20 * 20), 20, 20))
+  rdes <- rsa_design(~ dismat, list(dismat = dismat))
+  rsa_mod <- rsa_model(dset_info$dataset, rdes, regtype = "lm")
+  train_model(rsa_mod, dset_info$dataset$train_data,
+    dset_info$design$y_train,
+    indices = seq_len(ncol(dset_info$dataset$train_data)))
+}
+}

--- a/man/train_model.vector_rsa_model.Rd
+++ b/man/train_model.vector_rsa_model.Rd
@@ -23,3 +23,15 @@ A structure containing "scores" or similar second-order similarity results.
 \description{
 Train a vector RSA model
 }
+\examples{
+\donttest{
+  dset_info <- gen_sample_dataset(D = c(8, 8, 8), nobs = 20,
+    response_type = "categorical", data_mode = "image", nlevels = 2)
+  vdesign <- vector_rsa_design(2, dset_info$design$y_train,
+    dset_info$design$block_var)
+  vmodel <- vector_rsa_model(dset_info$dataset, vdesign)
+  train_model(vmodel, dset_info$dataset$train_data,
+    dset_info$design$y_train,
+    indices = seq_len(ncol(dset_info$dataset$train_data)))
+}
+}


### PR DESCRIPTION
## Summary
- centralize train_model documentation on the generic
- link S3 methods back to the generic
- add runnable examples to Rd files

## Testing
- `git diff --name-only --cached`
