### PR TITLE
Improve generic docs and link S3 methods

### DIFF
--- a/R/allgeneric.R
+++ b/R/allgeneric.R
@@ -60,6 +60,20 @@ select_features <- function(obj, X, Y, ...) {
 #' @param result The result object to be formatted.
 #' @param error_message An optional error message.
 #' @param ... Additional arguments to be passed to the method-specific function.
+#'
+#' @examples
+#' \donttest{
+#' dataset <- gen_sample_dataset(D = c(6, 6, 6), nobs = 20,
+#'                               response_type = "categorical",
+#'                               data_mode = "image")
+#' cval <- blocked_cross_validation(dataset$design$block_var)
+#' model <- load_model("sda_notune")
+#' mspec <- mvpa_model(model, dataset$dataset, dataset$design,
+#'                     "classification", crossval = cval)
+#' # Typically called internally during processing
+#' format_result(mspec, result = NULL, error_message = "example",
+#'               context = list(test = 1, ytest = factor("a")))
+#' }
 #' @export
 format_result <- function(obj, result, error_message, ...) {
   UseMethod("format_result")
@@ -329,6 +343,17 @@ performance <- function(x,...) {
 #' @param result The classification/regression result object to evaluate.
 #'
 #' @return A list of performance metrics.
+#'
+#' @examples
+#' cres <- binary_classification_result(
+#'   observed  = factor(c("a", "b")),
+#'   predicted = factor(c("a", "b")),
+#'   probs     = matrix(c(0.8, 0.2, 0.3, 0.7), ncol = 2,
+#'                      dimnames = list(NULL, c("a", "b")))
+#' )
+#' dummy <- list(performance = performance)
+#' class(dummy) <- "mvpa_model"
+#' compute_performance(dummy, cres)
 #' @export
 compute_performance <- function(obj, result) {
   UseMethod("compute_performance")
@@ -628,9 +653,15 @@ run_regional <- function(model_spec, region_mask, ...) {
 #' @param ... Extra arguments passed to the specific cross-validation methods.
 #'
 #' @return A tibble containing training and testing sets for each fold.
+#'
+#' @examples
+#' cval <- kfold_cross_validation(len = 20, nfolds = 4)
+#' dat  <- as.data.frame(matrix(rnorm(20 * 2), 20, 2))
+#' y    <- factor(rep(letters[1:4], 5))
+#' crossval_samples(cval, dat, y)
 #' @export
-crossval_samples <- function(obj, data, y,...) { 
-  UseMethod("crossval_samples") 
+crossval_samples <- function(obj, data, y,...) {
+  UseMethod("crossval_samples")
 }
 
 #' Generic Pairwise Distance Computation

--- a/R/crossval.R
+++ b/R/crossval.R
@@ -549,26 +549,31 @@ kfold_cross_validation <- function(len, nfolds=10) {
 # }
 
 #' @export
-crossval_samples.sequential_blocked_cross_validation <- function(obj, data, y,...) { 
+#' @rdname crossval_samples-methods
+crossval_samples.sequential_blocked_cross_validation <- function(obj, data, y,...) {
   crossv_seq_block(data, y, nfolds=obj$nfolds, block_var=obj$block_var, nreps=obj$nreps, block_ind=obj$block_ind)
 }
 
 #' @export
-crossval_samples.kfold_cross_validation <- function(obj, data,y,...) { 
+#' @rdname crossval_samples-methods
+crossval_samples.kfold_cross_validation <- function(obj, data,y,...) {
   crossv_k(data, y, obj$nfolds)
 }
 
 #' @export
-crossval_samples.blocked_cross_validation <- function(obj, data, y,...) { 
+#' @rdname crossval_samples-methods
+crossval_samples.blocked_cross_validation <- function(obj, data, y,...) {
   crossv_block(data, y, obj$block_var)
 }
 
 #' @export
-crossval_samples.bootstrap_blocked_cross_validation <- function(obj, data, y,...) { 
+#' @rdname crossval_samples-methods
+crossval_samples.bootstrap_blocked_cross_validation <- function(obj, data, y,...) {
   crossv_bootstrap_block(data, y, block_var=obj$block_var, nreps=obj$nreps, weights=obj$weights)
 }
 
 #' @export
+#' @rdname crossval_samples-methods
 #' @importFrom modelr resample
 crossval_samples.custom_cross_validation <- function(obj, data, y, id = ".id",...) {
   fold <- function(train, test) {
@@ -587,7 +592,8 @@ crossval_samples.custom_cross_validation <- function(obj, data, y, id = ".id",..
 }
 
 #' @export
-crossval_samples.twofold_blocked_cross_validation <- function(obj, data, y,...) { 
+#' @rdname crossval_samples-methods
+crossval_samples.twofold_blocked_cross_validation <- function(obj, data, y,...) {
   crossv_twofold(data, y, obj$block_var, obj$block_ind, nreps=obj$nreps)
 }
 

--- a/R/feature_rsa_model.R
+++ b/R/feature_rsa_model.R
@@ -1336,6 +1336,7 @@ y_train.feature_rsa_design <- function(obj) {
 }
 
 #' @export
+#' @rdname format_result-methods
 format_result.feature_rsa_model <- function(obj, result, error_message=NULL, context, ...) {
   
   if (!is.null(error_message)) {
@@ -1423,6 +1424,7 @@ format_result.feature_rsa_model <- function(obj, result, error_message=NULL, con
 }
 
 #' @export
+#' @rdname merge_results-methods
 merge_results.feature_rsa_model <- function(obj, result_set, indices, id, ...) {
  
   if (any(result_set$error)) {

--- a/R/manova_model.R
+++ b/R/manova_model.R
@@ -179,6 +179,7 @@ print.manova_design <- function(x, ...) {
 #' @importFrom tibble tibble
 #' @importFrom futile.logger flog.error flog.warn
 #' @method merge_results manova_model
+#' @rdname merge_results-methods
 merge_results.manova_model <- function(obj, result_set, indices, id, ...) {
   
   # Check for errors from previous steps (processor/train_model)

--- a/R/mvpa_model.R
+++ b/R/mvpa_model.R
@@ -45,6 +45,7 @@ wrap_result <- function(result_table, design, fit=NULL) {
 
 
 #' @keywords internal
+#' @rdname merge_results-methods
 merge_results.mvpa_model <- function(obj, result_set, indices, id, ...) {
   # Check if any errors occurred during the process
   if (any(result_set$error)) {
@@ -73,6 +74,7 @@ merge_results.mvpa_model <- function(obj, result_set, indices, id, ...) {
 }
 
 
+#' @rdname format_result-methods
 #' @noRd
 #' @importFrom stats predict
 format_result.mvpa_model <- function(obj, result, error_message=NULL, context, ...) {
@@ -125,6 +127,7 @@ get_custom_perf <- function(fun, split_list) {
 
 
 #' @keywords internal
+#' @rdname compute_performance-methods
 compute_performance.mvpa_model <- function(obj, result) {
   obj$performance(result)
 }
@@ -152,8 +155,9 @@ select_features.mvpa_model <- function(obj, X, Y,...) {
 
 
 #' @export
-crossval_samples.mvpa_model <- function(obj,data,y,...) { 
-  crossval_samples(obj$crossval,data,y) 
+#' @rdname crossval_samples-methods
+crossval_samples.mvpa_model <- function(obj,data,y,...) {
+  crossval_samples(obj$crossval,data,y)
 }
 
 #' @export

--- a/R/performance.R
+++ b/R/performance.R
@@ -72,6 +72,7 @@ custom_performance <- function(x, custom_fun, split_list=NULL) {
 }
 
 #' @method merge_results binary_classification_result
+#' @rdname merge_results-methods
 merge_results.binary_classification_result <- function(x,...) {
   rlist <- list(x,...)
   probs <- Reduce("+", lapply(rlist, function(x) x$probs))/length(rlist)
@@ -83,6 +84,7 @@ merge_results.binary_classification_result <- function(x,...) {
 }
 
 #' @method merge_results regression_result
+#' @rdname merge_results-methods
 merge_results.regression_result <- function(x,...) {
   rlist <- list(x,...)
   pred <- Reduce("+", lapply(rlist, function(x) x$predicted))/length(rlist)
@@ -103,6 +105,7 @@ prob_observed.multiway_classification_result <- function(x) {
 }
 
 #' @method merge_results multiway_classification_result
+#' @rdname merge_results-methods
 merge_results.multiway_classification_result <- function(x,...) {
   
   rlist <- list(x,...)

--- a/R/regional.R
+++ b/R/regional.R
@@ -144,6 +144,7 @@ combine_prediction_tables <- function(predtabs, wts=rep(1,length(predtabs)), col
 #'
 #' @return A merged \code{regional_mvpa_result} object.
 #' @method merge_results regional_mvpa_result
+#' @rdname merge_results-methods
 merge_results.regional_mvpa_result <- function(x, ...) {
   rlist <- list(x,...)
   combine_prediction_tables(rlist)

--- a/R/rsa_model.R
+++ b/R/rsa_model.R
@@ -424,6 +424,7 @@ train_model.rsa_model <- function(obj, train_dat, y, indices, ...) {
 #' @importFrom tibble tibble
 #' @importFrom futile.logger flog.error
 #' @method merge_results rsa_model
+#' @rdname merge_results-methods
 merge_results.rsa_model <- function(obj, result_set, indices, id, ...) {
   
   # Check for errors from previous steps (processor/train_model)

--- a/R/vector_rsa_model.R
+++ b/R/vector_rsa_model.R
@@ -458,6 +458,7 @@ evaluate_model.vector_rsa_model <- function(object,
 #' @importFrom tibble tibble
 #' @importFrom futile.logger flog.error flog.warn
 #' @method merge_results vector_rsa_model
+#' @rdname merge_results-methods
 merge_results.vector_rsa_model <- function(obj, result_set, indices, id, ...) {
   
   # Check for errors from previous steps (processor/train_model)


### PR DESCRIPTION
## Summary
- add examples for several generics
- link S3 methods to shared Rd files via `@rdname`
- centralize docs for `format_result`, `compute_performance`, and `crossval_samples`

## Testing
- `git status --short`