### PR TITLE
Add rdname tags for y_train generics with examples

### DIFF
--- a/R/allgeneric.R
+++ b/R/allgeneric.R
@@ -339,6 +339,11 @@ train_model <- function(obj,...) {
 #' Extract the training labels or response variable from an object.
 #'
 #' @param obj The object from which to extract the training response variable.
+#'
+#' @rdname y_train-methods
+#' @examples
+#' ds <- gen_sample_dataset(D = c(4, 4, 4), nobs = 10)
+#' y_train(ds$design)
 #' @export
 y_train <- function(obj) {
   UseMethod("y_train")
@@ -349,6 +354,11 @@ y_train <- function(obj) {
 #' Extract the test labels or response variable from an object.
 #'
 #' @param obj The object from which to extract the test response variable.
+#'
+#' @rdname y_test-methods
+#' @examples
+#' ds <- gen_sample_dataset(D = c(4, 4, 4), nobs = 10, external_test = TRUE)
+#' y_test(ds$design)
 #' @export
 y_test <- function(obj) {
   UseMethod("y_test")
@@ -359,6 +369,11 @@ y_test <- function(obj) {
 #' Return the design table associated with the test set from an object.
 #'
 #' @param obj The object from which to extract the test design table.
+#'
+#' @rdname test_design-methods
+#' @examples
+#' ds <- gen_sample_dataset(D = c(4, 4, 4), nobs = 10, external_test = TRUE)
+#' test_design(ds$design)
 #' @export
 test_design <- function(obj) {
   UseMethod("test_design")

--- a/R/design.R
+++ b/R/design.R
@@ -19,19 +19,23 @@ nresponses.mvpa_design <- function(x) {
 }
 
 #' @export
+#' has_test_set check for mvpa_design
 has_test_set.mvpa_design <- function(obj) {
-  !is.null(obj$y_test) 
+  !is.null(obj$y_test)
 }
 
 
+#' @rdname y_train-methods
 #' @export
 y_train.mvpa_design <- function(obj) obj$y_train
 
 
+#' @rdname y_test-methods
 #' @export
 y_test.mvpa_design <- function(obj) if (is.null(obj$y_test)) obj$y_train else obj$y_test
 
 
+#' @rdname test_design-methods
 #' @export
 test_design.mvpa_design <- function(obj) {
   if (is.null(obj$y_test)) obj$train_design else obj$test_design

--- a/R/feature_rsa_model.R
+++ b/R/feature_rsa_model.R
@@ -1333,11 +1333,13 @@ train_model.feature_rsa_model <- function(obj, X, y, indices, ...) {
 }
 
 
+#' @rdname y_train-methods
 #' @export
 y_train.feature_rsa_model <- function(obj) {
   obj$design$F  # Features are used as predictors (y in training function)
 }
 
+#' @rdname y_train-methods
 #' @export
 y_train.feature_rsa_design <- function(obj) {
   obj$F  # Features are used as predictors

--- a/R/mvpa_model.R
+++ b/R/mvpa_model.R
@@ -174,10 +174,12 @@ has_test_set.model_spec <- function(obj) {
 
 
 
+#' @rdname y_train-methods
 #' @export
 y_train.mvpa_model <- function(obj) y_train(obj$design)
 
 
+#' @rdname y_test-methods
 #' @export
 y_test.mvpa_model <- function(obj) y_test(obj$design)
 


### PR DESCRIPTION
## Summary
- document `y_train`, `y_test`, and `test_design` generics with examples
- reference these generic docs from mvpa_design, mvpa_model, and feature_rsa_model methods

## Testing
- `Rscript -e 'devtools::document()'` *(fails: command not found)*