### PR TITLE
Update strip_dataset docs

### DIFF
--- a/R/allgeneric.R
+++ b/R/allgeneric.R
@@ -12,17 +12,26 @@ get_unique_regions <- function(region_mask, ...) {
 }
 
 #' Strip Dataset from Model Specification
-#' 
+#'
 #' Removes the potentially large dataset component from a model specification object
 #' to avoid copying it during parallel processing.
-#' 
+#'
 #' @param obj The model specification object.
 #' @param ... Additional arguments.
 #' @return The model specification object with the `dataset` element removed or set to NULL.
+#' @rdname strip_dataset-methods
+#' @examples
+#' \donttest{
+#'   ds <- gen_sample_dataset(D = c(4, 4, 4), nobs = 20)
+#'   mdl <- load_model("sda_notune")
+#'   mspec <- mvpa_model(mdl, ds$dataset, ds$design, "classification")
+#'   stripped <- strip_dataset(mspec)
+#'   is.null(stripped$dataset)
+#' }
 #' @export
 strip_dataset <- function(obj, ...) {
   UseMethod("strip_dataset")
-} 
+}
 
 #' Select Features
 #'

--- a/R/mvpa_model.R
+++ b/R/mvpa_model.R
@@ -361,13 +361,7 @@ print.mvpa_model <- function(x,...) {
 }
   
 
-#' Default method for strip_dataset generic
-#' 
-#' Removes the `dataset` element from a model specification object.
-#' 
-#' @param obj The model specification object.
-#' @param ... Additional arguments (ignored).
-#' @return The object with `obj$dataset` set to NULL.
+#' @rdname strip_dataset-methods
 #' @export
 strip_dataset.default <- function(obj, ...) {
   if (!is.null(obj$dataset)) {
@@ -380,6 +374,7 @@ strip_dataset.default <- function(obj, ...) {
 }
 
 #' @noRd
+#' @rdname strip_dataset-methods
 #' @export
 strip_dataset.mvpa_model <- function(obj, ...) {
   obj$dataset <- NULL


### PR DESCRIPTION
## Summary
- document `strip_dataset` generic and methods under one rdname
- document example showing dataset stripping
- align method docs with `strip_dataset-methods`

## Testing
- `Rscript -e "devtools::document()"` *(fails: command not found)*