### PR TITLE
Update roxygen for selected S3 methods

### DIFF
--- a/R/allgeneric.R
+++ b/R/allgeneric.R
@@ -201,7 +201,7 @@ process_roi <- function(mod_spec, roi, rnum, ...) {
 #' @param center_global_id Optional global ID of the center voxel. Defaults to NA.
 #'
 #' @rdname process_roi-methods
-#' @keywords internal
+#' @export
 process_roi.default <- function(mod_spec, roi, rnum, center_global_id = NA, ...) {
   # Capture additional arguments to pass down
   dots <- list(...)

--- a/R/custom.R
+++ b/R/custom.R
@@ -285,7 +285,6 @@ run_custom_regional <- function(dataset, region_mask, custom_func, ...,
 # Add a dummy method for the internal class to satisfy mvpa_iterate checks
 #' @rdname process_roi-methods
 #' @export
-#' @keywords internal
 process_roi.custom_internal_model_spec <- function(mod_spec, roi, rnum, ...) {
   # This should not be called directly if the processor is provided,
   # but needs to exist.

--- a/R/manova_model.R
+++ b/R/manova_model.R
@@ -182,7 +182,7 @@ print.manova_design <- function(x, ...) {
 #' @importFrom futile.logger flog.error flog.warn
 #' @rdname merge_results-methods
 #' @method merge_results manova_model
-#' @rdname merge_results-methods
+#' @export
 merge_results.manova_model <- function(obj, result_set, indices, id, ...) {
   
   # Check for errors from previous steps (processor/train_model)

--- a/R/model_fit.R
+++ b/R/model_fit.R
@@ -203,6 +203,7 @@ predict.regression_model_fit <- function(object, newdata, sub_indices=NULL,...) 
 }
 
 
+#' @rdname merge_predictions-methods
 #' @export
 #' @method merge_predictions regression_prediction
 merge_predictions.regression_prediction <- function(obj1, rest, ...) {
@@ -223,6 +224,7 @@ merge_predictions.regression_prediction <- function(obj1, rest, ...) {
 }
 
 
+#' @rdname merge_predictions-methods
 #' @export
 #' @method merge_predictions classification_prediction
 merge_predictions.classification_prediction <- function(obj1, rest, ...) {

--- a/R/mvpa_model.R
+++ b/R/mvpa_model.R
@@ -44,8 +44,8 @@ wrap_result <- function(result_table, design, fit=NULL) {
 
 
 
-#' @keywords internal
 #' @rdname merge_results-methods
+#' @export
 merge_results.mvpa_model <- function(obj, result_set, indices, id, ...) {
   # Check if any errors occurred during the process
   if (any(result_set$error)) {
@@ -375,7 +375,6 @@ strip_dataset.default <- function(obj, ...) {
   obj
 }
 
-#' @noRd
 #' @rdname strip_dataset-methods
 #' @export
 strip_dataset.mvpa_model <- function(obj, ...) {

--- a/R/mvpa_result.R
+++ b/R/mvpa_result.R
@@ -88,7 +88,7 @@ binary_classification_result <- function(observed, predicted, probs, testind=NUL
 #' @return A \code{multiway_classification_result} object containing the subset of results specified by the indices.
 #'
 #' @export
-#' @family sub_result
+#' @rdname sub_result-methods
 sub_result.multiway_classification_result <- function(x, indices) {
   ret <- list(
     observed=x$observed[indices],
@@ -112,7 +112,7 @@ sub_result.multiway_classification_result <- function(x, indices) {
 #' @return A \code{binary_classification_result} object containing the subset of results specified by the indices.
 #'
 #' @export
-#' @family sub_result
+#' @rdname sub_result-methods
 sub_result.binary_classification_result <- function(x, indices) {
   ret <- list(
     observed=x$observed[indices],

--- a/R/performance.R
+++ b/R/performance.R
@@ -73,7 +73,7 @@ custom_performance <- function(x, custom_fun, split_list=NULL) {
 
 #' @rdname merge_results-methods
 #' @method merge_results binary_classification_result
-#' @rdname merge_results-methods
+#' @export
 merge_results.binary_classification_result <- function(x,...) {
   rlist <- list(x,...)
   probs <- Reduce("+", lapply(rlist, function(x) x$probs))/length(rlist)
@@ -86,7 +86,7 @@ merge_results.binary_classification_result <- function(x,...) {
 
 #' @rdname merge_results-methods
 #' @method merge_results regression_result
-#' @rdname merge_results-methods
+#' @export
 merge_results.regression_result <- function(x,...) {
   rlist <- list(x,...)
   pred <- Reduce("+", lapply(rlist, function(x) x$predicted))/length(rlist)
@@ -108,7 +108,7 @@ prob_observed.multiway_classification_result <- function(x) {
 
 #' @rdname merge_results-methods
 #' @method merge_results multiway_classification_result
-#' @rdname merge_results-methods
+#' @export
 merge_results.multiway_classification_result <- function(x,...) {
   
   rlist <- list(x,...)

--- a/R/regional.R
+++ b/R/regional.R
@@ -145,7 +145,7 @@ combine_prediction_tables <- function(predtabs, wts=rep(1,length(predtabs)), col
 #' @return A merged \code{regional_mvpa_result} object.
 #' @rdname merge_results-methods
 #' @method merge_results regional_mvpa_result
-#' @rdname merge_results-methods
+#' @export
 merge_results.regional_mvpa_result <- function(x, ...) {
   rlist <- list(x,...)
   combine_prediction_tables(rlist)

--- a/R/resample.R
+++ b/R/resample.R
@@ -27,7 +27,7 @@ get_samples.mvpa_surface_dataset <- function(obj, vox_list) {
 }
 
 
-#' @rdname data_sample
+#' @rdname data_sample-methods
 #' @export
 data_sample.mvpa_dataset <- function(obj, vox, ...) {
   structure(

--- a/R/vector_rsa_model.R
+++ b/R/vector_rsa_model.R
@@ -461,7 +461,7 @@ evaluate_model.vector_rsa_model <- function(object,
 #' @importFrom futile.logger flog.error flog.warn
 #' @rdname merge_results-methods
 #' @method merge_results vector_rsa_model
-#' @rdname merge_results-methods
+#' @export
 merge_results.vector_rsa_model <- function(obj, result_set, indices, id, ...) {
   
   # Check for errors from previous steps (processor/train_model)


### PR DESCRIPTION
## Summary
- add `@export` tags and remove internal keywords for some S3 methods
- reference generics via `@rdname <generic>-methods`
- clean up documentation of `strip_dataset.mvpa_model` and several helper methods

## Testing
- `Rscript` not available, cannot run R package tests
- `pytest` not available