### PR TITLE
Add runnable examples for selected generics

### DIFF
--- a/R/allgeneric.R
+++ b/R/allgeneric.R
@@ -817,6 +817,9 @@ filter_roi <- function(roi, ...) {
 #' @param obj A cross-validation specification object (e.g., inheriting from `cross_validation`).
 #' @param ... Additional arguments passed to methods.
 #' @return An integer representing the number of folds.
+#' @examples
+#' cval <- kfold_cross_validation(len = 20, nfolds = 4)
+#' get_nfolds(cval)
 #' @export
 get_nfolds <- function(obj, ...) {
   UseMethod("get_nfolds")
@@ -831,6 +834,9 @@ get_nfolds <- function(obj, ...) {
 #' @param fold_num An integer specifying the fold number for which to retrieve training indices.
 #' @param ... Additional arguments passed to methods.
 #' @return An integer vector of training indices.
+#' @examples
+#' cval <- kfold_cross_validation(len = 20, nfolds = 4)
+#' train_indices(cval, 1)
 #' @export
 train_indices <- function(obj, fold_num, ...) {
   UseMethod("train_indices")

--- a/R/performance.R
+++ b/R/performance.R
@@ -7,6 +7,12 @@
 #'
 #' @param prob A matrix of predicted probabilities with column names indicating the classes.
 #' @return A vector of predicted classes corresponding to the highest probability for each row in the input matrix.
+#' @examples
+#' prob <- matrix(c(0.2, 0.8,
+#'                  0.6, 0.4),
+#'                nrow = 2, byrow = TRUE,
+#'                dimnames = list(NULL, c("A", "B")))
+#' predicted_class(prob)
 #' @export
 predicted_class <- function(prob) {
   maxid <- max.col(prob, ties.method="random")
@@ -53,6 +59,17 @@ performance.regression_result <- function(x, split_list,...) {
 #' @details
 #' The function allows users to apply a custom performance metric to a prediction result object.
 #' If a split list is provided, the performance metric will be computed for each group separately, and the results will be returned as a named vector.
+#' @examples
+#' cres <- binary_classification_result(
+#'   observed  = factor(c("A", "B")),
+#'   predicted = factor(c("A", "A")),
+#'   probs = matrix(c(0.9, 0.1,
+#'                    0.6, 0.4),
+#'                  ncol = 2, byrow = TRUE,
+#'                  dimnames = list(NULL, c("A", "B")))
+#' )
+#' acc_fun <- function(x) mean(x$observed == x$predicted)
+#' custom_performance(cres, acc_fun)
 #' @export
 custom_performance <- function(x, custom_fun, split_list=NULL) {
   if (is.null(split_list)) {


### PR DESCRIPTION
## Summary
- add examples for `get_nfolds` and `train_indices` generics
- add example for `predicted_class`
- add example for `custom_performance`
- attempted `devtools::document()` but R is missing

## Testing
- `R -e "devtools::document()"` *(fails: command not found)*
- `Rscript -e "devtools::document()"` *(fails: command not found)*
- `R CMD check rMVPA.Rproj` *(fails: command not found)*