### PR TITLE
Improve fit_model documentation

### DIFF
--- a/R/allgeneric.R
+++ b/R/allgeneric.R
@@ -377,6 +377,27 @@ test_design <- function(obj) {
 #' @param last Logical indicating if this is the last iteration.
 #' @param classProbs Logical indicating if class probabilities should be returned.
 #' @param ... Additional arguments to be passed to the method-specific function.
+#'
+#' @examples
+#' \donttest{
+#'   ds <- gen_sample_dataset(
+#'     D = c(6, 6, 6), nobs = 20,
+#'     response_type = "categorical",
+#'     data_mode = "image", nlevels = 2
+#'   )
+#'   mdl <- load_model("sda_notune")
+#'   mspec <- mvpa_model(
+#'     model = mdl,
+#'     dataset = ds$dataset,
+#'     design  = ds$design,
+#'     model_type = "classification"
+#'   )
+#'   grid <- tune_grid(mspec, ds$dataset$train_data, ds$design$y_train, len = 1)
+#'   fit  <- fit_model(mspec, ds$dataset$train_data,
+#'                    ds$design$y_train, wts = NULL, param = grid)
+#' }
+#'
+#' @rdname fit_model-methods
 #' 
 #' @export
 fit_model <- function(obj, roi_x, y, wts, param, lev=NULL, last=FALSE, classProbs=FALSE, ...) {

--- a/R/model_fit.R
+++ b/R/model_fit.R
@@ -89,6 +89,7 @@ tune_model <- function(mspec, x, y, wts, param, nreps=10) {
 #' @param classProbs Logical; if TRUE, class probabilities should be computed (default is FALSE).
 #' @param ... Additional arguments to be passed to the underlying model fitting function.
 #' @return A fitted model object with additional attributes "obsLevels" and "problemType".
+#' @rdname fit_model-methods
 #' @noRd
 fit_model.mvpa_model <- function(obj, x, y, wts, param, classProbs, ...) {
   fit <- obj$model$fit(x,y,wts=wts,param=param,lev=levels(y), classProbs=classProbs, ...)

--- a/man/fit_model.Rd
+++ b/man/fit_model.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/allgeneric.R
 \name{fit_model}
 \alias{fit_model}
+\alias{fit_model.mvpa_model}
 \title{Fit Model}
 \usage{
 fit_model(
@@ -37,4 +38,23 @@ fit_model(
 }
 \description{
 Fit a classification or regression model.
+}
+\examples{
+\donttest{
+  ds <- gen_sample_dataset(
+    D = c(6, 6, 6), nobs = 20,
+    response_type = "categorical",
+    data_mode = "image", nlevels = 2
+  )
+  mdl <- load_model("sda_notune")
+  mspec <- mvpa_model(
+    model = mdl,
+    dataset = ds$dataset,
+    design = ds$design,
+    model_type = "classification"
+  )
+  grid <- tune_grid(mspec, ds$dataset$train_data, ds$design$y_train, len = 1)
+  fit <- fit_model(mspec, ds$dataset$train_data,
+                   ds$design$y_train, wts = NULL, param = grid)
+}
 }


### PR DESCRIPTION
## Summary
- document `fit_model` generic with an example
- link `fit_model.mvpa_model` to the generic docs
- regenerate manual page for `fit_model`

## Testing
- `R -q -e "devtools::document()"` *(fails: `R: command not found`)*