### PR TITLE
Add dataset-design consistency check for rsa_model

### DIFF
--- a/R/dataset.R
+++ b/R/dataset.R
@@ -467,5 +467,15 @@ has_test_set.mvpa_dataset <- function(obj) {
   isTRUE(obj$has_test_set)
 }
 
+#' @export
+nobs.mvpa_dataset <- function(x) {
+  dims <- dim(x$train_data)
+  if (is.null(dims)) {
+    length(x$train_data)
+  } else {
+    dims[length(dims)]
+  }
+}
+
 
 

--- a/R/rsa_model.R
+++ b/R/rsa_model.R
@@ -704,6 +704,25 @@ rsa_model <- function(dataset,
     check_collinearity(design$model_mat)
     message("Collinearity check passed.")
   }
+
+  # Verify that the number of observations in the dataset matches
+  # the size expected by the RSA design. This prevents obscure
+  # dimension errors later during model fitting.
+  nobs_dataset <- {
+    dims <- dim(dataset$train_data)
+    if (is.null(dims)) length(dataset$train_data) else dims[length(dims)]
+  }
+  expected_len <- choose(nobs_dataset, 2)
+  if (!is.null(design$include)) {
+    expected_len <- sum(design$include)
+  }
+  model_vec_len <- length(design$model_mat[[1]])
+  if (model_vec_len != expected_len) {
+    stop(sprintf(
+      "Mismatch between dataset observations (%s) and RSA design length (%s).",
+      nobs_dataset, model_vec_len
+    ))
+  }
   
   # Create the RSA model object
   obj <- create_model_spec(

--- a/tests/testthat/test_rsa_input_validation.R
+++ b/tests/testthat/test_rsa_input_validation.R
@@ -1,0 +1,9 @@
+test_that("rsa_model detects dataset/design mismatch", {
+  ds <- gen_sample_dataset(c(4,4,4), nobs = 10, blocks = 2)
+  D <- dist(matrix(rnorm(8 * 8), 8, 8))
+  rdes <- rsa_design(~ D, list(D = D))
+  expect_error(
+    rsa_model(ds$dataset, design = rdes),
+    "Mismatch between dataset observations"
+  )
+})


### PR DESCRIPTION
## Summary
- check observation count in `rsa_model` to stop early on dimension mismatch
- expose `nobs` method for mvpa_dataset
- add regression test for mismatched dataset and RSA design

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68470d8c53ec832d915568fb44baa77e