### PR TITLE
Fix performance column naming

### DIFF
--- a/R/searchlight.R
+++ b/R/searchlight.R
@@ -464,7 +464,7 @@ combine_randomized <- function(model_spec, good_results, bad_results=NULL) {
   perf_mat[ind_set,] <- sweep(perf_mat[ind_set,,drop=FALSE], 1, as.integer(ind_count), FUN="/")
   
   # Set column names from the performance metrics
-  colnames(perf_mat) <- names(good_results$performance[[1]])
+  colnames(perf_mat) <- colnames(good_results$performance[[1]])
   
   # Wrap and return results
   ret <- wrap_out(perf_mat, model_spec$dataset)

--- a/tests/testthat/test_rsa_searchlight.R
+++ b/tests/testthat/test_rsa_searchlight.R
@@ -126,14 +126,40 @@ test_that("randomized rsa_searchlight and blocking variable runs without error",
 
 test_that("standard rsa_searchlight and no blocking variable runs without error", {
   dataset <- gen_sample_dataset(c(5, 5, 5), 100, blocks = 3)
-  
+
   Dmat <- dist(matrix(rnorm(100 * 100), 100, 100))
   # Build RSA design without a blocking variable
   rdes <- rsa_design(~ Dmat, list(Dmat = Dmat))
-  
+
   for (regtype in c("lm", "rfit", "pearson", "spearman")) {
     mspec <- rsa_model(dataset$dataset, design = rdes, regtype = regtype)
     ret <- run_searchlight(mspec, radius = 4, method = "standard")
     expect_true(!is.null(ret))
   }
+})
+
+test_that("rsa_searchlight retains predictor names as metrics", {
+  dataset <- gen_sample_dataset(c(5, 5, 5), 20, blocks = 2)
+
+  D1 <- dist(matrix(rnorm(20 * 20), 20, 20))
+  D2 <- dist(matrix(rnorm(20 * 20), 20, 20))
+  rdes <- rsa_design(~ x1 + x2, list(x1 = D1, x2 = D2))
+
+  mspec <- rsa_model(dataset$dataset, design = rdes)
+  res <- run_searchlight(mspec, radius = 4, method = "standard")
+
+  expect_equal(res$metrics, c("x1", "x2"))
+})
+
+test_that("randomized rsa_searchlight retains predictor names as metrics", {
+  dataset <- gen_sample_dataset(c(5, 5, 5), 20, blocks = 2)
+
+  D1 <- dist(matrix(rnorm(20 * 20), 20, 20))
+  D2 <- dist(matrix(rnorm(20 * 20), 20, 20))
+  rdes <- rsa_design(~ x1 + x2, list(x1 = D1, x2 = D2))
+
+  mspec <- rsa_model(dataset$dataset, design = rdes)
+  res <- run_searchlight(mspec, radius = 4, method = "randomized", niter = 2)
+
+  expect_equal(res$metrics, c("x1", "x2"))
 })


### PR DESCRIPTION
## Summary
- fix setting of performance matrix column names for randomized searchlights
- add regression tests ensuring predictor names remain for RSA searchlight results

## Testing
- `R CMD build .` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68471f941524832d8a024ffc43276d6f