### PR TITLE
Harden ITEM decoding feature and add vignette

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Rscript -e "covr::package_coverage()"
   - RSA (Representational Similarity Analysis): Multiple variants
   - MANOVA: Multivariate ANOVA
   - MS-ReVE: Multi-Scale Representational Variance Explained (in `contrast_rsa_model.R`)
+  - **ITEM Decoding**: trial-wise decoding with analytic trial-covariance correction (`R/item_model.R`, `R/item_design.R`); delegates numerics to the optional `fmrilss` package. See `vignette("ITEM_Decoding")`.
   - **Continuous Decoding**: archived `hrfdecoder` materials live under `archive/hrfdecoder/` and are excluded from package builds
 
 - **Feature Selection**: Modular system supporting F-test, categorical scores, and custom methods

--- a/R/item_design.R
+++ b/R/item_design.R
@@ -81,7 +81,15 @@ item_design <- function(train_design = NULL,
     validate = TRUE
   )
 
-  # Keep cv_labels aligned with TR rows; ITEM folds are handled internally by run_id.
+  # ITEM invariant: cross-validation folds are derived internally by
+  # `fmrilss::item_cv()` from trial-level `run_id`, NOT from the mvpa_design
+  # block/cv machinery. cv_labels/targets are therefore deliberately set to TR
+  # row indices (placeholders aligned to nrow(X_t)) so the design satisfies the
+  # mvpa_design contract without implying a trial-level supervised signal.
+  # Consequently `y_train.item_design()` returns TR indices, not trial targets;
+  # an item_design is only meaningful when consumed by `item_model`. `block_var`
+  # is intentionally omitted for the same reason -- wiring run_id here would
+  # double up fold logic with item_cv.
   base <- mvpa_design(
     train_design = train_design,
     cv_labels = seq_len(n_time),
@@ -109,6 +117,9 @@ item_design <- function(train_design = NULL,
 #' @export
 #' @rdname y_train-methods
 y_train.item_design <- function(obj) {
+  # Returns TR row indices, not trial-level targets. See the ITEM invariant
+  # note in item_design(): supervised trial targets live in obj$T_target and
+  # are consumed directly by item_model/fmrilss::item_cv.
   obj$cv_labels
 }
 
@@ -124,7 +135,7 @@ print.item_design <- function(x, ...) {
   cat(sprintf("TR rows: %s\n", n_time))
   cat(sprintf("Trials: %s\n", n_trials))
   cat(sprintf("Runs: %s\n", n_runs))
-  cat(sprintf("Targets columns: %s\n", if (!is.null(x$T_target)) ncol(x$T_target) else NA_integer_))
+  cat(sprintf("Targets columns: %s\n", if (!is.null(x$T_target)) NCOL(x$T_target) else NA_integer_))
   invisible(x)
 }
 

--- a/R/item_model.R
+++ b/R/item_model.R
@@ -16,9 +16,9 @@
 #' @param dataset An `mvpa_dataset`.
 #' @param design An `item_design` object.
 #' @param mode Decoding mode: `"classification"` or `"regression"`.
-#' @param metric Optional ITEM metric.
-#'   Classification: `"accuracy"`, `"balanced_accuracy"`.
-#'   Regression: `"correlation"`, `"rmse"`.
+#' @param metric Optional ITEM metric. Validated against `mode` at
+#'   construction. Classification: `"accuracy"`, `"balanced_accuracy"`.
+#'   Regression: `"correlation"`, `"rmse"`. `NULL` uses the `fmrilss` default.
 #' @param ridge_u Non-negative ridge used when computing `U`.
 #' @param ridge_w Non-negative ridge used when fitting ITEM weights per fold.
 #' @param lsa_method LS-A backend for `fmrilss::lsa()` (`"r"` or `"cpp"`).
@@ -30,6 +30,13 @@
 #' @param compute_performance Reserved for API compatibility. ITEM always
 #'   computes scalar ROI metrics for mapping.
 #' @param ... Additional fields stored on the model spec.
+#'
+#' @details
+#' When `return_predictions = TRUE` (the default) the full per-fold
+#' cross-validation payload is retained on every ROI result. The searchlight
+#' schema combiner discards this payload and keeps only the scalar maps, but
+#' `run_regional()` retains the full results list; for analyses with many ROIs
+#' or large trial counts, pass `return_predictions = FALSE` to bound memory.
 #'
 #' @return A model spec of class `item_model` compatible with
 #'   `run_regional()` and `run_searchlight()`.
@@ -54,6 +61,7 @@ item_model <- function(dataset,
   lsa_method <- match.arg(lsa_method)
   solver <- match.arg(solver)
   u_storage <- match.arg(u_storage)
+  metric <- .item_validate_metric(metric, mode)
 
   assertthat::assert_that(inherits(dataset, "mvpa_dataset"))
   assertthat::assert_that(inherits(design, "item_design"), msg = "design must inherit class 'item_design'.")
@@ -149,6 +157,43 @@ item_model <- function(dataset,
     Nuisance = design$Nuisance,
     ...
   )
+}
+
+#' @keywords internal
+#' @noRd
+.item_metric_choices <- function(mode) {
+  switch(
+    mode,
+    classification = c("accuracy", "balanced_accuracy"),
+    regression = c("correlation", "rmse"),
+    character(0)
+  )
+}
+
+#' @keywords internal
+#' @noRd
+.item_validate_metric <- function(metric, mode) {
+  if (is.null(metric)) {
+    return(NULL)
+  }
+  if (!is.character(metric) || length(metric) != 1L || is.na(metric)) {
+    stop("metric must be NULL or a single character string.", call. = FALSE)
+  }
+
+  choices <- .item_metric_choices(mode)
+  if (!metric %in% choices) {
+    stop(
+      sprintf(
+        "metric '%s' is not valid for mode '%s'. Valid metrics: %s.",
+        metric,
+        mode,
+        paste(choices, collapse = ", ")
+      ),
+      call. = FALSE
+    )
+  }
+
+  metric
 }
 
 #' @rdname fit_roi
@@ -273,5 +318,8 @@ output_schema.item_model <- function(model) {
 #' @keywords internal
 #' @export
 process_roi.item_model <- function(mod_spec, roi, rnum, center_global_id = NA, ...) {
+  # Explicit S3 registration so item_model participates in the standard
+  # process_roi dispatch chain; behaviour is fully delegated to
+  # process_roi.default, which routes to the fit_roi.item_model shim.
   NextMethod()
 }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,6 +24,7 @@ articles:
   - Searchlight_Analysis
   - Regional_Analysis
   - Haxby_2001
+  - ITEM_Decoding
   - CommandLine
 - title: Representational Similarity Analysis
   desc: |

--- a/man/item_model.Rd
+++ b/man/item_model.Rd
@@ -28,9 +28,9 @@ item_model(
 
 \item{mode}{Decoding mode: `"classification"` or `"regression"`.}
 
-\item{metric}{Optional ITEM metric.
-Classification: `"accuracy"`, `"balanced_accuracy"`.
-Regression: `"correlation"`, `"rmse"`.}
+\item{metric}{Optional ITEM metric. Validated against `mode` at
+construction. Classification: `"accuracy"`, `"balanced_accuracy"`.
+Regression: `"correlation"`, `"rmse"`. `NULL` uses the `fmrilss` default.}
 
 \item{ridge_u}{Non-negative ridge used when computing `U`.}
 
@@ -71,4 +71,10 @@ the decoder is fit:
 
 Use ITEM when you want an explicit trial-estimation stage and direct control
 over trial covariance handling (`U`), especially for trial-level diagnostics.
+
+When `return_predictions = TRUE` (the default) the full per-fold
+cross-validation payload is retained on every ROI result. The searchlight
+schema combiner discards this payload and keeps only the scalar maps, but
+`run_regional()` retains the full results list; for analyses with many ROIs
+or large trial counts, pass `return_predictions = FALSE` to bound memory.
 }

--- a/tests/testthat/test-item-model.R
+++ b/tests/testthat/test-item-model.R
@@ -40,6 +40,65 @@ test_that("item_design validates dimensions and stores ITEM metadata", {
   )
 })
 
+test_that("item_model validates metric against mode at construction", {
+  set.seed(9011)
+
+  n_time <- 40
+  n_trials <- 12
+  ds <- gen_sample_dataset(c(3, 3, 3), nobs = n_time, blocks = 3, nlevels = 2)
+  X_t <- matrix(rnorm(n_time * n_trials), nrow = n_time, ncol = n_trials)
+  run_id <- rep(1:3, each = 4)
+  T_target <- as.numeric(scale(rnorm(n_trials)))
+
+  des <- item_design(
+    train_design = ds$design$train_design,
+    X_t = X_t,
+    T_target = T_target,
+    run_id = run_id
+  )
+
+  expect_error(
+    item_model(
+      dataset = ds$dataset,
+      design = des,
+      mode = "regression",
+      metric = "accuracy"
+    ),
+    "metric 'accuracy' is not valid for mode 'regression'"
+  )
+
+  expect_error(
+    item_model(
+      dataset = ds$dataset,
+      design = des,
+      mode = "classification",
+      metric = "rmse"
+    ),
+    "metric 'rmse' is not valid for mode 'classification'"
+  )
+
+  expect_error(
+    item_model(
+      dataset = ds$dataset,
+      design = des,
+      mode = "regression",
+      metric = c("rmse", "correlation")
+    ),
+    "metric must be NULL or a single character string"
+  )
+
+  expect_s3_class(
+    item_model(
+      dataset = ds$dataset,
+      design = des,
+      mode = "regression",
+      metric = NULL,
+      solver = "svd"
+    ),
+    "item_model"
+  )
+})
+
 test_that("item_model fit_roi path returns scalar metrics", {
   set.seed(9002)
 

--- a/vignettes/ITEM_Decoding.Rmd
+++ b/vignettes/ITEM_Decoding.Rmd
@@ -1,0 +1,277 @@
+---
+title: ITEM Trial-Wise Decoding
+author: rMVPA authors
+date: '`r Sys.Date()`'
+output: rmarkdown::html_vignette
+vignette: |
+  %\VignetteIndexEntry{ITEM Trial-Wise Decoding} %\VignetteEngine{knitr::rmarkdown} %\VignetteEncoding{UTF-8}
+params:
+  family: red
+  preset: homage
+css: albers.css
+resource_files:
+- albers.css
+- albers.js
+includes:
+  in_header: |-
+    <script src="albers.js"></script>
+    <script>document.addEventListener('DOMContentLoaded',function(){document.body.classList.add('palette-teal');});</script>
+
+---
+
+```{r setup, include=FALSE}
+if (requireNamespace("ggplot2", quietly = TRUE) && requireNamespace("albersdown", quietly = TRUE)) ggplot2::theme_set(albersdown::theme_albers(params$family))
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>", message = FALSE, warning = FALSE)
+has_fmrilss <- requireNamespace("fmrilss", quietly = TRUE)
+suppressPackageStartupMessages({
+  library(rMVPA)
+  library(neuroim2)
+})
+```
+
+```{r fmrilss-note, echo=FALSE, results='asis', eval=!has_fmrilss}
+cat("> **Note:** the `fmrilss` package is not installed, so the code in this",
+    "vignette is shown but not executed. Install it with",
+    "`remotes::install_github(\"bbuchsbaum/fmrilss\")` to run these examples.\n")
+```
+
+## Overview
+
+ITEM (Inverse Transformed Encoding Model) decoding is a trial-wise pipeline
+for ROI and searchlight analysis. Unlike standard MVPA, which decodes from a
+single pattern per trial without accounting for how overlapping hemodynamic
+responses correlate trial estimates, ITEM makes the trial-estimation step
+explicit and then *corrects for the covariance it induces*.
+
+The pipeline has two stages:
+
+1. **Trial estimation.** A least-squares-all (LS-A) GLM regresses the
+   TR-level data onto a trial-wise design matrix `X_t`, yielding one response
+   pattern per trial (`Gamma`).
+2. **Covariance-aware decoding.** Because nearby trials share overlapping
+   HRFs, the trial estimates are correlated even when the underlying signals
+   are not. ITEM computes this trial-by-trial covariance `U` analytically from
+   `X_t` and uses it to whiten the decoder, then evaluates with
+   leave-one-run-out cross-validation.
+
+This differs from the archived `hrfdecoder` pathway, which fit a
+continuous-time decoder directly on TR-level data and aggregated TR
+predictions to events afterward. Reach for ITEM when you want an explicit
+trial-estimation stage and direct control over trial covariance handling,
+especially for trial-level diagnostics.
+
+The implementation delegates the numerical work (`item_build_design`,
+`item_compute_u`, `lsa`, `item_cv`) to the
+[`fmrilss`](https://github.com/bbuchsbaum/fmrilss) package, which is an
+optional dependency.
+
+## The two ITEM objects
+
+| Object | Constructor | Role |
+|---|---|---|
+| Design | `item_design()` | Couples the trial-wise design matrix `X_t` and trial targets `T_target` to TR-level observations. |
+| Model spec | `item_model()` | Configures the decoder (mode, metric, ridge, solver) and precomputes `U`. Compatible with `run_regional()` and `run_searchlight()`. |
+
+The key distinction from a standard `mvpa_design` is that supervised
+information lives at the **trial** level (`T_target`, length `n_trials`),
+while the data extracted per ROI/searchlight lives at the **TR** level
+(`nrow(X_t)` rows). Cross-validation folds are derived internally from the
+trial-level `run_id` -- you do not specify a `block_var`.
+
+## Quick example
+
+We simulate a small dataset, build a trial-wise design, and run a regression
+decode over three ROIs.
+
+```{r build, eval=has_fmrilss}
+set.seed(42)
+
+n_time   <- 80   # TR-level observations
+n_trials <- 24   # trials to decode
+n_runs   <- 4
+
+data_info <- gen_sample_dataset(
+  D = c(10, 10, 10), nobs = n_time, nlevels = 2, blocks = n_runs
+)
+
+# Trial-wise design matrix: one column per trial (n_time x n_trials).
+# In real analyses this is built from your event onsets and an HRF.
+X_t    <- matrix(rnorm(n_time * n_trials), nrow = n_time, ncol = n_trials)
+run_id <- rep(seq_len(n_runs), each = n_trials / n_runs)
+
+# Continuous trial-level target (regression mode).
+T_target <- as.numeric(scale(rnorm(n_trials)))
+
+des <- item_design(
+  train_design = data_info$design$train_design,
+  X_t          = X_t,
+  T_target     = T_target,
+  run_id       = run_id
+)
+
+print(des)
+```
+
+```{r model, eval=has_fmrilss}
+model <- item_model(
+  dataset = data_info$dataset,
+  design  = des,
+  mode    = "regression",
+  metric  = "correlation",
+  solver  = "svd"
+)
+```
+
+```{r regional, eval=has_fmrilss}
+roi_mask <- NeuroVol(
+  sample(1:3, length(data_info$dataset$mask), replace = TRUE),
+  space(data_info$dataset$mask)
+)
+
+results <- run_regional(model, roi_mask)
+results$performance_table
+```
+
+Every ROI/searchlight location reports three scalars:
+
+- `item_score_mean` -- mean of the chosen metric across folds,
+- `item_score_sd` -- across-fold standard deviation,
+- `item_n_folds` -- number of cross-validation folds (runs).
+
+```{r check-regional, include=FALSE, eval=has_fmrilss}
+stopifnot(
+  is.data.frame(results$performance_table),
+  "item_score_mean" %in% names(results$performance_table),
+  all(is.finite(results$performance_table$item_score_mean))
+)
+```
+
+With random data the correlation hovers near zero. With real fMRI data, an
+`item_score_mean` reliably above zero (regression) or above chance
+(classification) indicates decodable trial-level structure.
+
+## Classification mode
+
+For categorical targets, pass a factor (or character vector) as `T_target`
+and set `mode = "classification"`:
+
+```{r classification, eval=has_fmrilss}
+T_class <- factor(rep(c("face", "house"), length.out = n_trials))
+
+des_cls <- item_design(
+  train_design = data_info$design$train_design,
+  X_t          = X_t,
+  T_target     = T_class,
+  run_id       = run_id
+)
+
+model_cls <- item_model(
+  dataset = data_info$dataset,
+  design  = des_cls,
+  mode    = "classification",
+  metric  = "balanced_accuracy",
+  solver  = "svd"
+)
+
+run_regional(model_cls, roi_mask)$performance_table
+```
+
+The `metric` argument is validated against `mode` at construction, so a
+mismatch (for example `mode = "classification"` with `metric = "rmse"`)
+fails immediately rather than producing a map of errored ROIs. Valid
+choices are `"accuracy"` / `"balanced_accuracy"` for classification and
+`"correlation"` / `"rmse"` for regression. `metric = NULL` uses the
+`fmrilss` default for the mode.
+
+## Searchlight
+
+The same model spec drops straight into `run_searchlight()`. ITEM exposes an
+output schema, so the searchlight produces one map per scalar metric:
+
+```{r searchlight, eval=has_fmrilss}
+sl <- run_searchlight(model, radius = 4, method = "standard")
+names(sl$results)
+```
+
+For whole-brain searchlights, set `return_predictions = FALSE` on the model
+spec. The searchlight schema combiner only keeps the scalar maps, but
+`run_regional()` retains the full per-fold prediction payload on every ROI;
+disabling predictions bounds memory when there are many ROIs or trials.
+
+## Accounting for temporal autocorrelation
+
+If you have an estimate of the TR-level noise covariance (or its precision),
+pass it through `V` / `v_type` on the design. ITEM folds it into the analytic
+trial covariance `U`:
+
+```{r covariance, eval=FALSE}
+# V_cov: n_time x n_time temporal covariance (e.g. from an AR model)
+des_v <- item_design(
+  train_design = train_design,
+  X_t          = X_t,
+  T_target     = T_target,
+  run_id       = run_id,
+  V            = V_cov,
+  v_type       = "cov"      # or "precision" if you pass the inverse
+)
+```
+
+Nuisance regressors that should be projected out during LS-A trial
+estimation (motion, drift) go through the `Z` / `Nuisance` arguments of
+`item_design()`.
+
+## Trial-alignment guard
+
+A common, hard-to-spot bug is a mismatch between the trial order in `X_t`
+and the trial order in your behavioural targets. ITEM can guard against this
+with a hash of the trial identifiers:
+
+```{r hash, eval=FALSE}
+des <- item_design(
+  X_t        = X_t,
+  T_target   = T_target,
+  run_id     = run_id,
+  trial_id   = trial_ids,
+  trial_hash = fmrilss:::.item_simple_hash(trial_ids)
+)
+
+model <- item_model(dataset, des, mode = "regression", check_hash = TRUE)
+```
+
+When `check_hash = TRUE`, each fold verifies the trial hash before decoding
+and the ROI fails loudly ("Trial hash mismatch") instead of silently
+returning a meaningless score.
+
+## Tuning knobs
+
+| Argument | Default | Purpose |
+|---|---|---|
+| `ridge_u` | `0` | Ridge added when inverting to form `U`. |
+| `ridge_w` | `1e-4` | Ridge on the per-fold ITEM weights. |
+| `solver` | `"chol"` | Linear solver (`"chol"`, `"svd"`, `"pinv"`); falls back to `"svd"` on collinearity. |
+| `u_storage` | `"matrix"` | Store `U` as a full matrix or per-run blocks (`"by_run"`); use blocks for many trials. |
+| `lsa_method` | `"r"` | LS-A backend (`"r"` or `"cpp"`). |
+
+## Troubleshooting
+
+**"requires package 'fmrilss'"** -- ITEM delegates its numerics to
+`fmrilss`. Install it with
+`remotes::install_github("bbuchsbaum/fmrilss")`.
+
+**"ROI rows ... must match nrow(X_t)"** -- the data extracted per ROI has a
+different number of TR rows than `X_t`. Confirm `nrow(X_t) == nobs(dataset)`
+and that the dataset and design describe the same scan.
+
+**"requested 'chol' but used 'svd'"** -- a benign fallback warning emitted
+when trial estimates are collinear within a fold; the decode still completes
+via the SVD solver. Increase `ridge_w` to suppress it.
+
+**Scores near chance everywhere** -- expected for null data. With real data,
+check that `X_t` is built from the correct onsets/HRF and that `T_target` is
+aligned to trials (consider the `check_hash` guard above).
+
+## Next steps
+
+- `?item_model`, `?item_design` -- full parameter documentation
+- `vignette("Naive_Cross_Decoding")` -- a no-learning cross-domain baseline
+- `vignette("Searchlight_Analysis")` -- general searchlight workflow


### PR DESCRIPTION
Address review findings on the item_model/item_design feature:

- Validate `metric` against `mode` at item_model() construction so a
  classification/regression mismatch fails fast instead of producing a
  whole map of errored ROIs; covered by new tests.
- Document the ITEM design invariant (folds derived from trial-level
  run_id, cv_labels/targets are TR-index placeholders, block_var
  intentionally omitted) in item_design() and y_train.item_design().
- Document the return_predictions memory tradeoff on the regional path.
- Fix print.item_design() to use NCOL() so a vector T_target still
  prints the targets-columns line.
- Clarify why process_roi.item_model() is an explicit NextMethod() shim.

Add vignette("ITEM_Decoding") and register it in _pkgdown.yml and
CLAUDE.md for discoverability (ITEM is the conceptual successor to the
archived hrfdecoder pathway).

https://claude.ai/code/session_01DHd4wbakNCejjyMnyhPpdu