### PR TITLE
Fix design variable parsing and result manifests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,11 @@
   of the call and restore the caller's previous `future` plan afterward.
 * `save_results()` now writes custom searchlight metric maps as NIfTI files
   instead of storing their wrappers as auxiliary R objects.
+* `save_results()` no longer loads optional surface packages merely to record
+  their versions when writing a volumetric-result manifest.
+* `mvpa_design()` now accepts row-aligned numeric, integer, character, logical,
+  and factor vectors for blocking and splitting variables, with explicit
+  alignment errors.
 * `era_rsa_model()` now accepts combined encoding/retrieval image series split
   explicitly by `phase_var`, validates optional one-to-one item pairing, and
   supports Pearson or Spearman matched-item similarity.

--- a/R/design.R
+++ b/R/design.R
@@ -52,6 +52,17 @@ test_design.mvpa_design <- function(obj) {
 parse_variable <- function(var, design) {
   ret <- if (purrr::is_formula(var)) {
     vnames <- all.vars(var[[2]])
+    missing_vars <- setdiff(vnames, names(design))
+    if (length(missing_vars)) {
+      stop(
+        sprintf(
+          "Formula variable%s not found in `design`: %s",
+          if (length(missing_vars) == 1L) "" else "s",
+          paste(missing_vars, collapse = ", ")
+        ),
+        call. = FALSE
+      )
+    }
     ret <- if (length(vnames) > 1) {
       do.call("interaction", c(lapply(vnames, function(vname) as.factor(design[[vname]])), sep=":"))
     } else {
@@ -67,13 +78,26 @@ parse_variable <- function(var, design) {
       stop(paste("`design` does not contain variable named: ", var))
     }
     design[[var]]
-  } else if (is.factor(var) || is.integer(var)) {
-    if (is.data.frame(design)) {
-      assertthat::assert_that(nrow(design) == length(var)) 
+  } else if (is.null(dim(var)) &&
+             (is.factor(var) || is.numeric(var) || is.character(var) || is.logical(var))) {
+    if (is.data.frame(design) && nrow(design) != length(var)) {
+      stop(
+        sprintf(
+          "Row-aligned `var` must have length %d to match `design`; got %d.",
+          nrow(design), length(var)
+        ),
+        call. = FALSE
+      )
     }
     var
   } else {
-    stop("'var' must be a formula, factor, or character vector")
+    stop(
+      paste0(
+        "`var` must be a formula, a single column name, or a row-aligned ",
+        "numeric, integer, character, logical, or factor vector."
+      ),
+      call. = FALSE
+    )
   }
   
   if (is.factor(ret)) {
@@ -95,8 +119,11 @@ parse_variable <- function(var, design) {
 #' @param y_train Formula or vector specifying the training response variable (old path;
 #'   mutually exclusive with \code{cv_labels})
 #' @param y_test Optional formula or vector specifying the test response variable (default: NULL)
-#' @param block_var Optional formula or vector specifying the blocking variable for cross-validation
-#' @param split_by Optional formula or vector for splitting analyses
+#' @param block_var Optional formula, scalar column name, or row-aligned numeric,
+#'   integer, character, logical, or factor vector specifying the blocking
+#'   variable for cross-validation.
+#' @param split_by Optional formula, scalar column name, or row-aligned atomic
+#'   vector specifying how to split analyses.
 #' @param cv_labels Optional vector of labels used for cross-validation fold construction
 #'   (new path; mutually exclusive with \code{y_train}). If provided without \code{targets},
 #'   \code{targets} defaults to \code{cv_labels}.
@@ -120,8 +147,10 @@ parse_variable <- function(var, design) {
 #' The \code{y_train} and \code{y_test} can be specified either as formulas (e.g., ~ condition)
 #' or as vectors. If formulas are used, they are evaluated within the respective design matrices.
 #'
-#' The \code{block_var} and \code{split_by} can also be specified as formulas or vectors.
-#' If formulas, they are evaluated within the training design matrix.
+#' The \code{block_var} and \code{split_by} can be specified as formulas, scalar
+#' column names, or row-aligned atomic vectors. Formulas and column names are
+#' evaluated within the relevant design matrix; vectors must have exactly one
+#' value per design row.
 #'
 #' The new \code{cv_labels} and \code{targets} parameters allow separating the labels used
 #' for fold construction from the actual training targets. When using the old \code{y_train}

--- a/R/save_results.R
+++ b/R/save_results.R
@@ -449,8 +449,13 @@ save_results.searchlight_result <- function(x, dir,
         created = as.character(Sys.time()),
         rMVPA_version   = tryCatch(as.character(utils::packageVersion("rMVPA")), error = function(e) NA_character_),
         neuroim2_version = tryCatch(as.character(utils::packageVersion("neuroim2")), error = function(e) NA_character_),
-        neurosurf_version = if (requireNamespace("neurosurf", quietly = TRUE))
-          as.character(utils::packageVersion("neurosurf")) else NA_character_,
+        # Reading DESCRIPTION metadata does not load the optional namespace.
+        # A broken optional neurosurf installation must not prevent volumetric
+        # results and their manifest from being saved.
+        neurosurf_version = tryCatch(
+          as.character(utils::packageVersion("neurosurf")),
+          error = function(e) NA_character_
+        ),
         class = class(x),
         metrics = names_all,
         runtime = .manifest_runtime_context(x),

--- a/man/mvpa_design.Rd
+++ b/man/mvpa_design.Rd
@@ -26,9 +26,12 @@ mutually exclusive with \code{cv_labels})}
 
 \item{y_test}{Optional formula or vector specifying the test response variable (default: NULL)}
 
-\item{block_var}{Optional formula or vector specifying the blocking variable for cross-validation}
+\item{block_var}{Optional formula, scalar column name, or row-aligned numeric,
+integer, character, logical, or factor vector specifying the blocking
+variable for cross-validation.}
 
-\item{split_by}{Optional formula or vector for splitting analyses}
+\item{split_by}{Optional formula, scalar column name, or row-aligned atomic
+vector specifying how to split analyses.}
 
 \item{cv_labels}{Optional vector of labels used for cross-validation fold construction
 (new path; mutually exclusive with \code{y_train}). If provided without \code{targets},
@@ -60,8 +63,10 @@ response variables, and optional blocking and splitting factors.
 The \code{y_train} and \code{y_test} can be specified either as formulas (e.g., ~ condition)
 or as vectors. If formulas are used, they are evaluated within the respective design matrices.
 
-The \code{block_var} and \code{split_by} can also be specified as formulas or vectors.
-If formulas, they are evaluated within the training design matrix.
+The \code{block_var} and \code{split_by} can be specified as formulas, scalar
+column names, or row-aligned atomic vectors. Formulas and column names are
+evaluated within the relevant design matrix; vectors must have exactly one
+value per design row.
 
 The new \code{cv_labels} and \code{targets} parameters allow separating the labels used
 for fold construction from the actual training targets. When using the old \code{y_train}

--- a/tests/testthat/test_custom_searchlight.R
+++ b/tests/testthat/test_custom_searchlight.R
@@ -287,4 +287,5 @@ test_that("save_results writes custom searchlight performance maps", {
   expect_true(file.exists(file.path(out, "maps", "mean_signal.nii.gz")))
   expect_false(dir.exists(file.path(out, "aux")))
   expect_true(length(paths$maps) == 1L)
+  expect_true(file.exists(paths$manifest))
 })

--- a/tests/testthat/test_design_parse_variable.R
+++ b/tests/testthat/test_design_parse_variable.R
@@ -1,0 +1,77 @@
+test_that("mvpa_design accepts supported block variable specifications", {
+  design <- data.frame(
+    condition = factor(rep(c("a", "b"), 4)),
+    subject = rep(c("s1", "s2"), each = 4),
+    run = rep(1:4, each = 2)
+  )
+
+  formula_design <- mvpa_design(design, y_train = ~ condition, block_var = ~ run)
+  named_design <- mvpa_design(design, y_train = ~ condition, block_var = "run")
+  multi_formula <- mvpa_design(
+    design,
+    y_train = ~ condition,
+    block_var = ~ subject + run
+  )
+
+  expect_identical(formula_design$block_var, design$run)
+  expect_identical(named_design$block_var, design$run)
+  expect_identical(
+    multi_formula$block_var,
+    droplevels(interaction(factor(design$subject), factor(design$run), sep = ":"))
+  )
+})
+
+test_that("mvpa_design accepts row-aligned atomic block vectors", {
+  design <- data.frame(condition = factor(rep(c("a", "b"), 4)))
+  inputs <- list(
+    factor = factor(rep(c("r1", "r2"), each = 4), levels = c("r1", "r2", "unused")),
+    integer = rep(1:2, each = 4),
+    double = as.double(rep(1:2, each = 4)),
+    character = rep(c("r1", "r2"), each = 4),
+    logical = rep(c(FALSE, TRUE), each = 4)
+  )
+
+  parsed <- lapply(inputs, function(blocks) {
+    mvpa_design(design, y_train = ~ condition, block_var = blocks)$block_var
+  })
+
+  expect_identical(parsed$factor, droplevels(inputs$factor))
+  expect_identical(parsed$integer, inputs$integer)
+  expect_identical(parsed$double, inputs$double)
+  expect_identical(parsed$character, inputs$character)
+  expect_identical(parsed$logical, inputs$logical)
+
+  split_design <- mvpa_design(
+    design,
+    y_train = ~ condition,
+    split_by = inputs$character
+  )
+  expect_identical(
+    split_design$split_groups,
+    split(seq_len(nrow(design)), inputs$character)
+  )
+})
+
+test_that("mvpa_design rejects ambiguous or misaligned variable inputs clearly", {
+  design <- data.frame(
+    condition = factor(rep(c("a", "b"), 4)),
+    run = rep(1:4, each = 2)
+  )
+
+  expect_error(
+    mvpa_design(design, y_train = ~ condition, block_var = c(1, 2)),
+    "must have length 8.*got 2"
+  )
+  expect_error(
+    mvpa_design(design, y_train = ~ condition, block_var = ~ missing_run),
+    "Formula variable not found.*missing_run"
+  )
+  expect_error(
+    mvpa_design(design, y_train = ~ condition, block_var = "missing_run"),
+    "does not contain variable named"
+  )
+  expect_error(
+    mvpa_design(design, y_train = ~ condition, block_var = matrix(1:8, ncol = 1)),
+    "row-aligned"
+  )
+})


### PR DESCRIPTION
## What changed

- Accept row-aligned numeric, integer, character, logical, and factor vectors in `mvpa_design()` variable parsing.
- Preserve formula and scalar column-name forms, with explicit errors for missing columns and row-count mismatches.
- Avoid loading the optional `neurosurf` namespace merely to record its installed version in volumetric result manifests.
- Extend custom-searchlight manifest coverage and add a focused design-parser contract suite.
- Update public `mvpa_design()` documentation and NEWS.

## Why

Issue #66 reproduces on current `master`: a numeric-double `block_var` aligned to the design rows is rejected even though the equivalent formula and integer forms work.

The custom metric map conversion requested in #65 is already present on `master`, but its exact `level = "standard"` workflow exposed an independent robustness problem: manifest metadata eagerly loaded an optional surface package after writing the NIfTI maps. A broken optional installation could therefore abort an otherwise volumetric export.

## Verification

- Built `rMVPA_0.1.2.tar.gz` and installed that exact artifact into an isolated library.
- Fresh-process #66 probe accepted formula, column-name, factor, integer, double, character, and logical forms; wrong-length and missing-formula inputs produced explicit errors.
- Fresh-process #65 probe ran 125 custom searchlights and read back three NIfTI maps with matching dimensions and spatial geometry; `manifest.yaml` was written and no `aux/` fallback was created.
- `test_design_parse_variable.R`: pass.
- `test_save_results.R`: pass.
- `test_custom_searchlight.R`: pass, with two existing CRAN skips.
- `test_mvpa_searchlight.R`: pass, with existing warnings and extended-test skips.
- `test_era_rsa_design.R` and `test_pair_rsa_design.R`: pass.
- `git diff --check`: pass.

Closes #66.
